### PR TITLE
Read ip and keyspace from APIHandler

### DIFF
--- a/src/main/scala/threesixty/persistence/cassandra/CassandraConnector.scala
+++ b/src/main/scala/threesixty/persistence/cassandra/CassandraConnector.scala
@@ -1,7 +1,7 @@
 package threesixty.persistence.cassandra
 
+import com.typesafe.config.{ConfigException, ConfigFactory, Config}
 import com.websudos.phantom.connectors.{ContactPoints, KeySpace}
-import threesixty.server.APIHandler
 
 /**
   * Created by Stefan Cimander on 19.01.16.
@@ -11,10 +11,18 @@ trait CassandraKeyspace {
 }
 
 object CassandraConnector extends CassandraKeyspace {
+    val config: Config = ConfigFactory.load
+
+    @throws[ConfigException]("if config doesn't contain database.address") // TODO
+    val dbAddress: String =
+        config.getString("database.address")
+    @throws[ConfigException]("if config doesn't contain database.keyspace") // TODO
+    val dbKeyspace: String =
+        config.getString("database.keyspace")
+
     // val hosts = Seq("137.250.170.136")
     // val hosts = Seq("localhost")
-    val hosts = Seq(APIHandler.dbAddress)
-    val dbKeyspace = APIHandler.dbKeyspace
+    val hosts = Seq(dbAddress)
 
     val keyspace = ContactPoints(hosts).keySpace(dbKeyspace)
 }

--- a/src/main/scala/threesixty/server/APIHandler.scala
+++ b/src/main/scala/threesixty/server/APIHandler.scala
@@ -30,13 +30,6 @@ object APIHandler {
 
     val config: Config = ConfigFactory.load
 
-    @throws[ConfigException]("if config doesn't contain database.address") // TODO
-    val dbAddress: String =
-        config.getString("database.address")
-    @throws[ConfigException]("if config doesn't contain database.keyspace") // TODO
-    val dbKeyspace: String =
-        config.getString("database.keyspace")
-
     val debug: Boolean = try {
         config.getBoolean("debug")
     } catch {


### PR DESCRIPTION
The ip and keyspace is now read from the APIHandler.

One alternative I've found is to load the information from the config
again but since Thomas Weber does not want the config to be loaded
multiple times this option was neglected.

If someone has a better idea feel free to implement it or let me know.
